### PR TITLE
Fixing issues related to old PR

### DIFF
--- a/src/main/java/net/gudenau/minecraft/largebar/mixin/client/InGameHudMixin.java
+++ b/src/main/java/net/gudenau/minecraft/largebar/mixin/client/InGameHudMixin.java
@@ -42,9 +42,9 @@ public abstract class InGameHudMixin extends DrawableHelper{
             } break;
             case VERTICAL:{
                 // Top half
-                drawTexture(matrices, x, y - 21, 0, 0, 182, 21);
+                drawTexture(matrices, x, y - 20, 0, 0, 182, 21);
                 // Bottom half
-                drawTexture(matrices, x, y, 0, 1, 182, 21);
+                drawTexture(matrices, x, y + 1, 0, 1, 182, 21);
             } break;
             default:{
                 drawTexture(matrices, x, y, u, v, width, height);
@@ -133,8 +133,8 @@ public abstract class InGameHudMixin extends DrawableHelper{
         index = 2
     )
     private int renderHotbar$hotbarSelectionY(int original){
-        if(LargeBarClient.getHotbarMode() != LargeBarClient.HotbarMode.HORIZONTAL){
-            return original - (getCameraPlayer().getInventory().selectedSlot / 9) * 20 - 1;
+        if(LargeBarClient.getHotbarMode() == LargeBarClient.HotbarMode.VERTICAL){
+            return original - (getCameraPlayer().getInventory().selectedSlot / 9) * 20;
         }else{
             return original;
         }
@@ -201,7 +201,7 @@ public abstract class InGameHudMixin extends DrawableHelper{
             return y;
         }else{
             // We need to calculate the index for this....
-            return y - ((gud_largebar$lastIndex / 9) * 20) - 1;
+            return y - (gud_largebar$lastIndex / 9) * 20;
         }
     }
     


### PR DESCRIPTION
in #8 i sought to fix a quantity of off-by-one rendering errors.  
as it turns out, there was actually only one error. under the assumption there were multiple, i  had originally pushed a bunch of textures 1 pixel in the wrong direction, in the interest of manually tweaking alignment.  

these textures _were_ aligned, but in some hotbar modes, the hotbar was 1 pixel higher than it appeared in vanilla.  
so, this PR undoes those old changes, and fixes the error in the _correct_ place. for real this time. largebar should, hopefully for good, be completely indistinguishable from vanilla's hotbar.  

whoops! sorry!